### PR TITLE
Fix crashing embedded sidekiq with sidekiq-cront because of incorrect signature

### DIFF
--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -14,7 +14,7 @@ module Sidekiq
       attr_reader :cron_poller
 
       # Add cron poller and execute normal initialize of Sidekiq launcher.
-      def initialize(config, embeded: true)
+      def initialize(config, embedded: true)
         config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
 
         @cron_poller = Sidekiq::Cron::Poller.new(config) if config[:cron_poll_interval] > 0

--- a/lib/sidekiq/cron/launcher.rb
+++ b/lib/sidekiq/cron/launcher.rb
@@ -14,7 +14,7 @@ module Sidekiq
       attr_reader :cron_poller
 
       # Add cron poller and execute normal initialize of Sidekiq launcher.
-      def initialize(config)
+      def initialize(config, embeded: true)
         config[:cron_poll_interval] = DEFAULT_POLL_INTERVAL if config[:cron_poll_interval].nil?
 
         @cron_poller = Sidekiq::Cron::Poller.new(config) if config[:cron_poll_interval] > 0


### PR DESCRIPTION


`3.1.0/gems/sidekiq-7.0.2/lib/sidekiq/embedded.rb` calls `@launcher = Sidekiq::Launcher.new(@config, embedded: true)`


https://github.com/sidekiq-cron/sidekiq-cron/issues/387